### PR TITLE
Update required PHP version in composer.json to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "wordpress", "composer", "wp", "plugin", "migrate", "env", "pro"
   ],
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.0",
     "composer-plugin-api": "^1.0",
     "vlucas/phpdotenv": "^2.2"
   },


### PR DESCRIPTION
https://github.com/Harmonic/wp-migrate-db-pro-installer/blob/5579b55a6da8354f5224d2b24d2038dad8be5066/src/WPMDBProInstaller/Plugin.php#L190

Type declaration of type `string` requires at least PHP v7.0, see http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.types.